### PR TITLE
Fjerner unødvendig timeout.

### DIFF
--- a/public/app/game/cxbirdGame.js
+++ b/public/app/game/cxbirdGame.js
@@ -67,7 +67,7 @@
             now = Date.now(),
             dt = now - this.time,
             self = this;
-        this.timer = window.requestAnimationFrame(function () { setTimeout(function () { self.render(); }, 5); });
+        this.timer = window.requestAnimationFrame(function() { self.render(); });
 
         this.time = now;
         //this.renderBackground(ctx);


### PR DESCRIPTION
Det bør ikke være nødvendig å ha en setTimeout når du regner ut tidsdelta. I tillegg vil det være omtrent 16 ms mellom hvert bilde (med mindre det har skjedd noe nytt med requestAnimationFrame som gjør at den kan tegne raskere enn 60 Hz). En ekstra timeout kan føre til at det går rundt 33 ms mellom to bilder hvis funksjonen som tegnet opp bildet tok lenger enn 11 ms.

Om du vet om noen andre grunner til å beholde setTimeout (med en så kort timeout), så er det selvfølgelig bare å ignorere denne PRen.